### PR TITLE
docs(readme): dodaj Grok do badge platformy

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Wersja stabilna](https://img.shields.io/badge/stabilna-21.08.2026-2A6F50.svg)](#-wersjonowanie)
 [![Wersja rozwojowa](https://img.shields.io/badge/rozwojowa-aktywna-orange.svg)](#-wersjonowanie)
 [![Skille](https://img.shields.io/badge/skille-33-8A2BE2.svg)](#-katalog-skilli)
-[![Platforma](https://img.shields.io/badge/platforma-Claude%20%C2%B7%20ChatGPT%20%C2%B7%20Codex-D97757.svg)](#-kompatybilno%C5%9B%C4%87-llm)
+[![Platforma](https://img.shields.io/badge/platforma-Claude%20%C2%B7%20ChatGPT%20%C2%B7%20Codex%20%C2%B7%20Grok-D97757.svg)](#-kompatybilno%C5%9B%C4%87-llm)
 [![Język](https://img.shields.io/badge/j%C4%99zyk-polski-white.svg?labelColor=DC143C)](#)
 
 *System pokrywa 16 dziedzin prawa polskiego i unijnego: od routingu sprawy, przez analizę


### PR DESCRIPTION
## Cel

Badge „Platforma" u góry README pomijał Grok, mimo że sekcja Kompatybilność LLM
i Krok 6 instalacji już go opisują.

## Zmiana

- Badge platformy: `Claude · ChatGPT · Codex` → `Claude · ChatGPT · Codex · Grok`.

Zmiana dotyczy wyłącznie dokumentacji (`README.md`).

https://claude.ai/code/session_01L3ZqvXhSQorixenRzTAPrU

---
_Generated by [Claude Code](https://claude.ai/code/session_01L3ZqvXhSQorixenRzTAPrU)_