### PR TITLE
F-135 — cross-check wartości prawnych

### DIFF
--- a/Wersja rozwojowa rozpakowana/audyt-systemu-v4/references/F-135-cross-check-wartosci-prawnych-2026-08-28.md
+++ b/Wersja rozwojowa rozpakowana/audyt-systemu-v4/references/F-135-cross-check-wartosci-prawnych-2026-08-28.md
@@ -1,0 +1,49 @@
+# F-135 — cross-check wartości prawnych — 2026-08-28
+
+## Cel
+
+Systematyczna kontrola twardych wartości normatywnych w DR i `shared`: kwot, progów, stawek, terminów, procentów, okresów oraz innych parametrów, których błędna wartość może zmienić wynik analizy.
+
+## Zasada zaliczenia
+
+Pozycja jest zaliczona wyłącznie gdy:
+1. wskazano dokładny moduł i twierdzenie/wartość;
+2. wartość porównano ze źródłem urzędowym aktualnym na dzień weryfikacji;
+3. wynik oznaczono jako `POTWIERDZONA`, `SKORYGOWANA` albo `NIEWERYFIKOWALNA`;
+4. przy korekcie zmieniono źródłowy moduł, nie tylko raport;
+5. weryfikacja części wartości nie jest przedstawiana jako weryfikacja całego modułu.
+
+## Batch 1 — DR-07 / PZP / KIO
+
+**Moduł:** `dr-07-zamowienia-publiczne-fundusze-ue/modules/mod-PZP-zamowienia-publiczne-KIO.md`
+
+**Źródła urzędowe:**
+- ELI, Prawo zamówień publicznych, t.j. Dz.U. 2026 poz. 793: https://eli.gov.pl/eli/DU/2026/793/ogl
+- UZP, progi unijne 2026–2027 / M.P. 2025 poz. 1247: https://www.gov.pl/web/uzp/aktualne-progi-unijne-oraz-ich-rownowartosci-w-zlotych-na-lata-2026-2027
+- ELI, rozporządzenie Prezesa RM o wpisach KIO, Dz.U. 2020 poz. 2437: https://eli.gov.pl/eli/DU/2020/2437/ogl
+
+| Wartość / reguła | Wynik | Stan po cross-checku |
+|---|---|---|
+| próg krajowy PZP dla zamówień klasycznych zamawiających publicznych | POTWIERDZONA | 170 000 zł, art. 2 ust. 1 pkt 1 PZP |
+| kurs EUR dla progów 2026–2027 | POTWIERDZONA | 4,31 zł |
+| roboty budowlane — próg UE | POTWIERDZONA | 5 404 000 EUR / 23 291 240 zł |
+| dostawy/usługi — administracja centralna | POTWIERDZONA | 140 000 EUR / 603 400 zł |
+| dostawy/usługi — pozostali zamawiający klasyczni | POTWIERDZONA | 216 000 EUR / 930 960 zł |
+| usługi społeczne klasyczne | POTWIERDZONA | 750 000 EUR / 3 232 500 zł |
+| dostawy/usługi sektorowe | POTWIERDZONA | 432 000 EUR / 1 861 920 zł |
+| usługi społeczne sektorowe | POTWIERDZONA | 1 000 000 EUR / 4 310 000 zł |
+| wpis KIO poniżej progów UE | **SKORYGOWANA** | 7 500 zł dla dostaw/usług lub konkursu; **10 000 zł dla robót budowlanych** |
+| wpis KIO na poziomie/progach UE | POTWIERDZONA | 15 000 zł dostawy/usługi lub konkurs; 20 000 zł roboty |
+| termin zapłaty wpisu | **SKORYGOWANA redakcyjnie** | wpis musi być uiszczony najpóźniej do upływu terminu wniesienia odwołania; 3-dniowe wezwanie z art. 518 dotyczy braków / dowodu terminowej zapłaty, nie dodatkowego terminu na spóźnioną zapłatę |
+| terminy odwołania art. 515 ust. 1–2 | POTWIERDZONE | 10/15 dni ≥ UE; 5/10 dni < UE; dokumenty/ogłoszenie 10 dni ≥ UE i 5 dni < UE |
+| zmiana umowy de minimis, art. 455 ust. 2 | **SKORYGOWANA** | 10% wartości pierwotnej dla dostaw/usług, 15% dla robót budowlanych, jednocześnie poniżej progów UE i bez zmiany ogólnego charakteru umowy |
+
+## Granica batcha
+
+Batch 1 nie oznacza pełnej re-weryfikacji wszystkich wartości w module PZP/KIO. W szczególności kolejne terminy szczególnych trybów, wartości kwalifikujące przesłanki wykluczenia oraz inne parametry wykonania umowy pozostają do osobnego sprawdzenia, jeśli wejdą do kolejnych batchy F-135.
+
+## Następne priorytety
+
+1. DR-06 — wartości podatkowe i limity o najwyższej zmienności;
+2. DR-03 — progi/terminy karne i wykroczeniowe o znaczeniu kwalifikacyjnym;
+3. `shared` — wartości powielane między dziedzinami, gdzie rozjazd propaguje się globalnie.

--- a/Wersja rozwojowa rozpakowana/dr-07-zamowienia-publiczne-fundusze-ue/modules/mod-PZP-zamowienia-publiczne-KIO.md
+++ b/Wersja rozwojowa rozpakowana/dr-07-zamowienia-publiczne-fundusze-ue/modules/mod-PZP-zamowienia-publiczne-KIO.md
@@ -286,7 +286,7 @@ ZAKAZ ZMIAN ISTOTNYCH (art. 454 PZP):
 DOPUSZCZALNE ZMIANY (art. 455 PZP) — katalog zamknięty:
   □ Klauzula przeglądowa przewidziana w SWZ (zakres, charakter, warunki zmian)
   □ Nowy wykonawca: sukcesja, restrukturyzacja, gwarancja (art. 455 ust. 1 pkt 2)
-  □ Wartość do 15% (dostawy/usługi) lub 15% (roboty) — łącznie
+  □ Art. 455 ust. 2: łączna wartość zmian musi być jednocześnie mniejsza niż progi unijne i niższa niż 10% wartości pierwotnej umowy (dostawy/usługi) albo 15% (roboty budowlane); bez zmiany ogólnego charakteru umowy — re-ver ELI 2026-08-28
   □ Okoliczności nieprzewidywalne (art. 455 ust. 1 pkt 4):
     → COVID, konflikt zbrojny, gwałtowny wzrost cen materiałów, klęska żywiołowa
   □ Zmiana nieistotna (test: czy zmiana wpłynęłaby na krąg oferentów lub wynik przetargu)

--- a/Wersja rozwojowa rozpakowana/dr-07-zamowienia-publiczne-fundusze-ue/modules/mod-PZP-zamowienia-publiczne-KIO.md
+++ b/Wersja rozwojowa rozpakowana/dr-07-zamowienia-publiczne-fundusze-ue/modules/mod-PZP-zamowienia-publiczne-KIO.md
@@ -1,7 +1,7 @@
 # mod-PZP-zamowienia-publiczne-KIO
 
 **Status:** moduł klasy kancelaryjnej — poziom DR-03
-**Źródło weryfikacji:** PZP — Dz.U. 2026 poz. 793 t.j. (obwieszczenie Marszałka Sejmu z 27.05.2026, publ. 16.06.2026, zastępuje t.j. 2024.1320; uwzględnia zm.: poz. 620, 769, 794, 1165, 1173, 1235, 252/2026) | Progi UE 2026–2027: M.P. 2025 poz. 1247 | Wpisy KIO: Dz.U. 2020 poz. 2437 ✅ VER: 2026-06-09
+**Źródło weryfikacji:** PZP — Dz.U. 2026 poz. 793 t.j. (obwieszczenie Marszałka Sejmu z 27.05.2026, publ. 16.06.2026) | Progi UE 2026–2027: M.P. 2025 poz. 1247 / UZP | Wpisy KIO: Dz.U. 2020 poz. 2437, § 2; art. 517–519 PZP — re-ver 2026-08-28
 **Data weryfikacji online:** 2026-08-15 (FAZA 3E — audyt-systemu-v4, korekta numeru t.j. + treść art. 226 pkt 17/19)
 **Zasada:** Każde brzmienie przepisu i kwota wpisu → weryfikuj w ISAP / uzp.gov.pl przed powołaniem
 
@@ -30,7 +30,7 @@ Postępowanie o udzielenie zamówienia publicznego, odwołanie do KIO, skarga na
 | Akt | Dz.U. / źródło |
 |---|---|
 | Ustawa PZP | Dz.U. 2026 poz. 793 t.j. (obwieszczenie 27.05.2026; zastępuje t.j. 2024.1320) ze zm. poz. 252/2026 (odrzucenie ofert ICT, w życie 3.04.2026) |
-| Rozporządzenie Prezesa RM o wpisach KIO | Dz.U. 2020 poz. 2437 ✅ VER: 2026-06-09 | Stawki: 7 500 / 15 000 / 20 000 zł |
+| Rozporządzenie Prezesa RM o wpisach KIO | Dz.U. 2020 poz. 2437, status ELI: obowiązujący; re-ver 2026-08-28 | Stawki: dostawy/usługi 7 500 zł (< UE) / 15 000 zł (≥ UE); roboty budowlane 10 000 zł (< UE) / 20 000 zł (≥ UE) |
 | Progi unijne 2026–2027 | M.P. 2025 poz. 1247 — obwieszczenie Prezesa UZP z 08.12.2025 |
 | KC | stosowany posiłkowo do umów (art. 8 PZP) |
 
@@ -95,11 +95,13 @@ PONIŻEJ PROGÓW UE (art. 515 ust. 1 pkt 2 PZP):
 WPIS OD ODWOŁANIA (art. 519 PZP):
   → Wpłacić najpóźniej do dnia upływu terminu na wniesienie odwołania
   → Kwoty (Dz.U. 2020 poz. 2437 — VER: 2026-06-09, nadal obowiązuje):
-     • 7 500 zł  — zamówienia o wartości poniżej progów unijnych
-     • 15 000 zł — zamówienia unijne na dostawy lub usługi
-     • 20 000 zł — zamówienia unijne na roboty budowlane
+     • 7 500 zł  — dostawy/usługi lub konkurs poniżej progów unijnych
+     • 10 000 zł — roboty budowlane poniżej progów unijnych
+     • 15 000 zł — dostawy/usługi lub konkurs na poziomie progów unijnych lub powyżej
+     • 20 000 zł — roboty budowlane na poziomie progów unijnych lub powyżej
   → Konto UZP: uzp.gov.pl/kio (rachunek podany na stronie UZP)
-  ⚠️ NIEZAPŁACONY WPIS = KIO wzywa do uzupełnienia w 3 dniach
+  ⚠️ Wpis musi być UISZCZONY najpóźniej do upływu terminu wniesienia odwołania (art. 517 ust. 2 PZP).
+  ⚠️ 3-dniowe wezwanie z art. 518 PZP służy poprawieniu/uzupełnieniu braków albo złożeniu DOWODU uiszczenia wpisu w terminie; nie tworzy dodatkowego terminu na spóźnioną zapłatę.
      Brak = zwrot odwołania bez rozpoznania meritum
 
 SKARGA NA ORZECZENIE KIO (art. 580 PZP):


### PR DESCRIPTION
## Zakres

Start F-135: urzędowa weryfikacja twardych wartości normatywnych (kwoty, progi, stawki, terminy, procenty) z rozróżnieniem `POTWIERDZONA / SKORYGOWANA / NIEWERYFIKOWALNA`.

## Batch 1 — DR-07 / PZP / KIO

Źródła urzędowe: ELI PZP Dz.U. 2026 poz. 793, ELI rozporządzenie o wpisach KIO Dz.U. 2020 poz. 2437, UZP / M.P. 2025 poz. 1247.

Naprawiono:
- wpis KIO poniżej progów UE: rozróżnienie 7 500 zł dla dostaw/usług lub konkursu oraz **10 000 zł dla robót budowlanych**;
- art. 517–519 PZP: 3-dniowe wezwanie dotyczy braków / dowodu terminowej zapłaty, nie dodatkowego terminu na spóźnioną zapłatę;
- art. 455 ust. 2 PZP: **10% dostawy/usługi, 15% roboty budowlane**, przy jednoczesnym warunku wartości poniżej progów UE.

Potwierdzono także 170 000 zł oraz główne progi UE 2026–2027 i kurs 4,31 zł.

Dodano rejestr:
`audyt-systemu-v4/references/F-135-cross-check-wartosci-prawnych-2026-08-28.md`.

## Granica

To jest pierwszy batch F-135, nie deklaracja pełnej weryfikacji całego modułu PZP/KIO ani zamknięcia F-135.

PR #23 (F-138) pozostaje osobnym, gotowym pakietem technicznym; ten PR jest niezależną serią merytorycznej weryfikacji wartości.