### PR TITLE
F-135 — DR-06 legal values batch 2

### DIFF
--- a/Wersja rozwojowa rozpakowana/audyt-systemu-v4/references/F-135-cross-check-wartosci-prawnych-2026-08-28.md
+++ b/Wersja rozwojowa rozpakowana/audyt-systemu-v4/references/F-135-cross-check-wartosci-prawnych-2026-08-28.md
@@ -47,3 +47,28 @@ Batch 1 nie oznacza pełnej re-weryfikacji wszystkich wartości w module PZP/KIO
 1. DR-06 — wartości podatkowe i limity o najwyższej zmienności;
 2. DR-03 — progi/terminy karne i wykroczeniowe o znaczeniu kwalifikacyjnym;
 3. `shared` — wartości powielane między dziedzinami, gdzie rozjazd propaguje się globalnie.
+
+
+## Batch 2 — DR-06 / Ordynacja podatkowa
+
+**Moduły:**
+- `dr-06-podatki-finanse-publiczne-aml/modules/mod-OP-czynnosci-sprawdzajace-dzial-V.md`
+- `dr-06-podatki-finanse-publiczne-aml/modules/mod-OP-ulgi-w-splacie-dzial-III-rozdzial-7a.md`
+
+**Źródła urzędowe:**
+- ELI / API Sejmu, Ordynacja podatkowa — t.j. Dz.U. 2026 poz. 622;
+- EUR-Lex — rozporządzenie Komisji (UE) 2023/2831;
+- UOKiK — „Zasady pomocy de minimis”.
+
+| Wartość / reguła | Wynik | Stan po cross-checku |
+|---|---|---|
+| art. 274 § 1 pkt 1 Op. — limit korekty deklaracji dokonywanej przez organ | POTWIERDZONA | 5000 zł w obowiązującym t.j. Dz.U. 2026 poz. 622 |
+| art. 274 § 3 Op. — sprzeciw od korekty organu | POTWIERDZONA | 14 dni od doręczenia uwierzytelnionej kopii skorygowanej deklaracji |
+| art. 67da § 2 Op. — wygaśnięcie decyzji ratalnej | POTWIERDZONA | niedotrzymanie terminu płatności trzech rat; przepis nie ustanawia wymogu, aby były kolejne |
+| art. 57 § 2 Op. — opłata prolongacyjna | POTWIERDZONA | stawka opłaty prolongacyjnej = obniżona stawka odsetek za zwłokę |
+| de minimis — limit ogólny | POTWIERDZONA | 300 000 EUR |
+| de minimis — sposób liczenia okresu | **SKORYGOWANA** | kroczący okres poprzednich 3 lat; usunięto błędny skrót „rok bieżący + 2 poprzednie lata podatkowe” |
+
+### Temporal gate
+
+Na dzień 2026-08-28 ELI wskazuje Dz.U. 2026 poz. 622 jako obowiązujący tekst jednolity Ordynacji podatkowej. Akty Dz.U. 2026 poz. 825 i 846 są oznaczone jako oczekujące na wejście w życie, więc batch 2 nie aktywuje ich wartości przed właściwymi datami temporalnymi.

--- a/Wersja rozwojowa rozpakowana/dr-06-podatki-finanse-publiczne-aml/modules/mod-OP-czynnosci-sprawdzajace-dzial-V.md
+++ b/Wersja rozwojowa rozpakowana/dr-06-podatki-finanse-publiczne-aml/modules/mod-OP-czynnosci-sprawdzajace-dzial-V.md
@@ -4,9 +4,10 @@
 Ordynacja podatkowa, Dz.U. 2026 poz. 622 t.j.
 
 Utworzony 2026-08-22 (F-83, priorytet #3 mapy pokrycia dr-06 — "najczęstsza,
-najmniej sformalizowana forma kontaktu z organem"). Zweryfikowane RZĄD 1:
-lexlege.pl, przepisy.gofin.pl (historia wersji do Dz.U. 2026 poz. 622), arslege.pl
-— zgodne przy każdym cytowanym artykule.
+najmniej sformalizowana forma kontaktu z organem"). Re-weryfikacja F-135:
+2026-08-28, RZĄD 1 — urzędowy tekst jednolity Ordynacji podatkowej,
+Dz.U. 2026 poz. 622 (ELI/API Sejmu). Potwierdzone m.in. art. 274 § 1 pkt 1:
+próg 5000 zł oraz art. 274 § 3: sprzeciw w terminie 14 dni.
 
 ## Akt prawny
 
@@ -233,4 +234,6 @@ KWOTOWY
 
 ## Weryfikacja online
 
-isap.sejm.gov.pl | lexlege.pl | przepisy.gofin.pl (historia wersji artykułów) | orzeczenia.nsa.gov.pl (dla wyroków cytowanych powyżej: I SA/Po 500/08, II FSK 985/15, I SA/Wr 268/15, III SA/Wa 1251/18 — WSZYSTKIE wymagają potwierdzenia sygnatury przy konkretnym wykorzystaniu, zgodnie z HARDGATE)
+**RZĄD 1:** ELI / API Sejmu — Dz.U. 2026 poz. 622, re-ver 2026-08-28 (art. 274: 5000 zł i 14 dni potwierdzone).  
+**Pomocniczo:** lexlege.pl, przepisy.gofin.pl (historia wersji artykułów).  
+**Orzecznictwo:** orzeczenia.nsa.gov.pl — sygnatury I SA/Po 500/08, II FSK 985/15, I SA/Wr 268/15, III SA/Wa 1251/18 wymagają osobnego fresh gate przed powołaniem.

--- a/Wersja rozwojowa rozpakowana/dr-06-podatki-finanse-publiczne-aml/modules/mod-OP-ulgi-w-splacie-dzial-III-rozdzial-7a.md
+++ b/Wersja rozwojowa rozpakowana/dr-06-podatki-finanse-publiczne-aml/modules/mod-OP-ulgi-w-splacie-dzial-III-rozdzial-7a.md
@@ -167,8 +167,11 @@ REŻIMY POMOCOWE
   - podstawa: **rozporządzenie Komisji (UE) 2023/2831 z 13.12.2023**
     (Dz.Urz. UE L z 15.12.2023), obowiązuje od **1.01.2024 do 31.12.2030**
     — ZASTĄPIŁO rozporządzenie 1407/2013 [RZĄD 1 — eur-lex, uokik.gov.pl]
-  - pułap: **300 000 EUR** w okresie **3 lat** (rok bieżący + 2 poprzednie
-    lata podatkowe) — jeden wspólny limit dla WSZYSTKICH sektorów;
+  - pułap: **300 000 EUR** w okresie **3 lat liczonym krocząco** — dla każdego
+    nowego przyznania uwzględnia się pomoc przyznaną w **poprzednich 3 latach**;
+    ⛔ NIE stosuj dawnego skrótu „rok bieżący + 2 poprzednie lata podatkowe”
+    (re-ver F-135: EUR-Lex 2023/2831 motyw 11 i art. 3 ust. 2 + UOKiK,
+    2026-08-28) — jeden wspólny limit dla wszystkich sektorów;
     transport drogowy towarów zrównany z pozostałymi (było 100 000 EUR)
   - usługi w ogólnym interesie gospodarczym (UOIG): odrębne rozp.
     **2023/2832** (zastąpiło 360/2012)
@@ -455,10 +458,10 @@ ROZDZIAŁU)
 
 | Twierdzenie | Rząd źródła | Źródła |
 |---|---|---|
-| Brzmienie art. 67a, 67b, 67c, 67d, 67e | RZĄD 2B | lexlege.pl, arslege.pl, przepisy.gofin.pl (metryka Dz.U. 2026 poz. 622) |
-| Istnienie i brzmienie art. 67da; przeniesienie z art. 259; „trzy raty niekoniecznie kolejne" | RZĄD 2B + 2A | lexlege.pl, arslege.pl, przepisy.gofin.pl, prawo.pl, inforfk.pl (+ RZĄD 3: podatkowyreferat.online, itbps.pl — zbieżne) |
-| Brzmienie art. 57 (opłata prolongacyjna) | RZĄD 2B | przepisy.gofin.pl (wprost przy Dz.U. 2026 poz. 622), arslege.pl, lexlege.pl |
-| Rozp. 2023/2831, limit 300 000 EUR, okres 3 lat, zastąpienie 1407/2013, dzień udzielenia pomocy | **RZĄD 1** | eur-lex.europa.eu, uokik.gov.pl („Zasady pomocy de minimis") |
+| Brzmienie art. 67a, 67b, 67c, 67d, 67e | **RZĄD 1** | ELI / API Sejmu, Dz.U. 2026 poz. 622; re-ver 2026-08-28 |
+| Istnienie i brzmienie art. 67da; skutek po niedotrzymaniu terminu płatności **trzech rat** bez warunku ich kolejności | **RZĄD 1** | ELI / API Sejmu, Dz.U. 2026 poz. 622, art. 67da § 2; re-ver 2026-08-28 |
+| Brzmienie art. 57 (opłata prolongacyjna; stawka = obniżona stawka odsetek za zwłokę) | **RZĄD 1** | ELI / API Sejmu, Dz.U. 2026 poz. 622, art. 57; re-ver 2026-08-28 |
+| Rozp. 2023/2831, limit 300 000 EUR, **kroczący okres poprzednich 3 lat** (nie „rok bieżący + 2 poprzednie lata podatkowe”), zastąpienie 1407/2013 | **RZĄD 1** | EUR-Lex 2023/2831 (motyw 11, art. 3 ust. 2) + UOKiK „Zasady pomocy de minimis”; re-ver 2026-08-28 |
 | Uznanie administracyjne — spełnienie przesłanek nie gwarantuje ulgi | **RZĄD 1** | mazowieckie.kas.gov.pl (Drugi Mazowiecki US, sekcja „Pomoc publiczna") |
 | NSA III FSK 4790/21 — podstawa materialnoprawna art. 67b § 1 pkt 2 | RZĄD 2 | inforlex.pl (treść uzasadnienia) |
 | Art. 67b § 1 pkt 2 nie zwalnia z badania przesłanek z art. 67a | RZĄD 2A | lex.pl |


### PR DESCRIPTION
## Zakres

F-135 batch 2: urzędowy cross-check twardych wartości normatywnych w DR-06 / Ordynacji podatkowej.

## Wynik

Poprawiono realny błąd:
- pomoc de minimis 300 000 EUR pozostaje poprawna, ale okres nie jest liczony jako „rok bieżący + 2 poprzednie lata podatkowe”; zgodnie z rozporządzeniem 2023/2831 jest to **kroczący okres poprzednich 3 lat**.

Potwierdzono w urzędowym tekście Op. Dz.U. 2026 poz. 622:
- art. 274 § 1 pkt 1: **5000 zł**;
- art. 274 § 3: **14 dni** na sprzeciw;
- art. 67da § 2: niedotrzymanie terminu płatności **trzech rat**, bez wymogu ich kolejności;
- art. 57 § 2: stawka opłaty prolongacyjnej = obniżona stawka odsetek za zwłokę.

Źródła: ELI/API Sejmu, EUR-Lex 2023/2831, UOKiK.

Zaktualizowano również rejestr:
`audyt-systemu-v4/references/F-135-cross-check-wartosci-prawnych-2026-08-28.md`.

## Temporal gate

Dz.U. 2026 poz. 622 jest bieżącym obowiązującym t.j. Op. na 2026-08-28; akty 825/846 pozostają oczekujące na wejście w życie i nie są przedwcześnie aktywowane.